### PR TITLE
fix typo in include

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,4 @@
-const Head = require('./Head.js');
+const Head = require('./head.js');
 const INJECTION_POINT = '</head>';
 
 function headPlugin(eleventyConfig) {


### PR DESCRIPTION
avoid the error on linux `Error: Cannot find module './Head.js'`